### PR TITLE
Adding object mapping conventions

### DIFF
--- a/src/Lucene.Net.ObjectMapping.Tests/Lucene.Net.ObjectMapping.Tests.csproj
+++ b/src/Lucene.Net.ObjectMapping.Tests/Lucene.Net.ObjectMapping.Tests.csproj
@@ -36,6 +36,10 @@
     <Reference Include="Lucene.Net">
       <HintPath>..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/src/Lucene.Net.ObjectMapping.Tests/ObjectMappingTest.cs
+++ b/src/Lucene.Net.ObjectMapping.Tests/ObjectMappingTest.cs
@@ -1,4 +1,5 @@
 ﻿using Lucene.Net.Documents;
+using Lucene.Net.Mapping;
 using Lucene.Net.ObjectMapping.Tests.Model;
 using NUnit.Framework;
 using System;
@@ -8,6 +9,33 @@ namespace Lucene.Net.ObjectMapping.Tests
     [TestFixture]
     public class ObjectMappingTest
     {
+		[Test]
+		public void ShouldRespectConventions()
+		{
+			var obj = new TestObject
+			{
+				String = "This is a test!"
+			};
+
+			var customMappingSettings = new MappingSettings
+			{
+				ObjectMapper = new JsonObjectMapper(new Conventions
+				{
+					ShouldStringFieldBeAnalyzed = (name, type) => false,
+					ShouldStringFieldBeStored = (name, type) => true
+				})
+			};
+
+			var docWithDefaultConventions = obj.ToDocument();
+			var docWithCustomConventions = obj.ToDocument(customMappingSettings);
+
+			Assert.True(docWithDefaultConventions.GetField("String").IsTokenized);
+			Assert.False(docWithDefaultConventions.GetField("String").IsStored);
+
+			Assert.False(docWithCustomConventions.GetField("String").IsTokenized);
+			Assert.True(docWithCustomConventions.GetField("String").IsStored);
+		}
+
         [Test]
         public void PropertyTypes()
         {

--- a/src/Lucene.Net.ObjectMapping.Tests/packages.config
+++ b/src/Lucene.Net.ObjectMapping.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Lucene.Net" version="3.0.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net451" />
 </packages>

--- a/src/Lucene.Net.ObjectMapping/Lucene.Net.ObjectMapping.csproj
+++ b/src/Lucene.Net.ObjectMapping/Lucene.Net.ObjectMapping.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Linq\QueryContext.cs" />
     <Compile Include="Linq\QueryOperators.cs" />
     <Compile Include="Linq\QueryProvider.cs" />
+    <Compile Include="Mapping\Conventions.cs" />
     <Compile Include="Mapping\GenericFields.cs" />
     <Compile Include="Mapping\IObjectMapper.cs" />
     <Compile Include="Mapping\JsonFieldNameResolver.cs" />

--- a/src/Lucene.Net.ObjectMapping/Mapping/Conventions.cs
+++ b/src/Lucene.Net.ObjectMapping/Mapping/Conventions.cs
@@ -1,0 +1,74 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Lucene.Net.Mapping
+{
+	/// <summary>
+	/// Mapping conventions are defined in this class. Essentially,
+	/// those are kind of "rules" that define how objects will be mapped to Lucene documents
+	/// </summary>
+	public class Conventions
+	{
+		private Func<string, JTokenType, bool> _shouldFieldBeAnalyzed;
+
+		/// <summary>
+		/// should set the specified field to be analyzed? field name and its type
+		/// are used to decide whether it should be analyzed or not
+		/// </summary>
+		public Func<string, JTokenType, bool> ShouldStringFieldBeAnalyzed
+		{
+			get
+			{
+				return _shouldFieldBeAnalyzed ?? Default.ShouldStringFieldBeAnalyzed;
+			}
+			set
+			{
+				_shouldFieldBeAnalyzed = value;
+			}
+		}
+
+		private Func<string, JTokenType, bool> _shouldFieldBeStored;
+
+		/// <summary>
+		/// should set the specified field to be stored? field name and its type
+		/// are used to decide whether it should be stored or not
+		/// </summary>
+		public Func<string, JTokenType, bool> ShouldStringFieldBeStored
+		{
+			get
+			{
+				return _shouldFieldBeStored ?? Default.ShouldStringFieldBeStored;
+			}
+			set
+			{
+				_shouldFieldBeStored = value;
+			}
+		}
+
+		private static Conventions _default;
+		private static readonly object _syncObj = new object();
+		
+		/// <summary>
+		/// Default conventions for mapping
+		/// </summary>
+		public static readonly Conventions Default = new Conventions
+		{
+			ShouldStringFieldBeAnalyzed = (fieldName, fieldType) =>
+			{
+				if (fieldType == JTokenType.String ||
+					fieldType == JTokenType.Uri)
+					return true;
+
+				return false;
+			},
+
+			ShouldStringFieldBeStored = (fieldName, fieldType) =>
+			{
+				return false;
+			},
+		};
+	}
+}

--- a/src/Lucene.Net.ObjectMapping/Mapping/IObjectMapper.cs
+++ b/src/Lucene.Net.ObjectMapping/Mapping/IObjectMapper.cs
@@ -9,6 +9,11 @@ namespace Lucene.Net.Mapping
     /// </summary>
     public interface IObjectMapper
     {
+		/// <summary>
+		/// conventions to use when mapping objects
+		/// </summary>
+		Conventions Conventions { get; set; }
+
         /// <summary>
         /// Adds the given source object to the specified Document.
         /// </summary>

--- a/src/Lucene.Net.ObjectMapping/Mapping/JsonObjectMapper.cs
+++ b/src/Lucene.Net.ObjectMapping/Mapping/JsonObjectMapper.cs
@@ -29,7 +29,21 @@ namespace Lucene.Net.Mapping
 
         #endregion
 
-        #region IObjectMapper Implementation
+		#region Constructor(s)
+
+		public JsonObjectMapper(Conventions conventions)
+		{
+			if (null == conventions)
+				throw new ArgumentNullException("conventions");
+
+			Conventions = conventions;
+		}
+
+		#endregion
+
+		#region IObjectMapper Implementation
+
+		public Conventions Conventions { get; set; }
 
         /// <summary>
         /// Adds the given source object to the specified Document.
@@ -90,7 +104,7 @@ namespace Lucene.Net.Mapping
         /// <param name="token">
         /// The JToken to add.
         /// </param>
-        private static void Add(Document doc, string prefix, JToken token)
+        private void Add(Document doc, string prefix, JToken token)
         {
             if (token is JObject)
             {
@@ -104,6 +118,11 @@ namespace Lucene.Net.Mapping
             {
                 JValue value = token as JValue;
                 IConvertible convertible = value as IConvertible;
+
+				var stringFieldStore = (Conventions.ShouldStringFieldBeStored(prefix, value.Type)) ? 
+					Field.Store.YES : Field.Store.NO;
+				var stringFieldAnalyze = (Conventions.ShouldStringFieldBeAnalyzed(prefix, value.Type)) ?
+					Field.Index.ANALYZED : Field.Index.NOT_ANALYZED;
 
                 switch (value.Type)
                 {
@@ -138,7 +157,7 @@ namespace Lucene.Net.Mapping
                         break;
 
                     case JTokenType.String:
-                        doc.Add(new Field(prefix, value.Value.ToString(), Field.Store.NO, Field.Index.ANALYZED));
+						doc.Add(new Field(prefix, value.Value.ToString(), stringFieldStore, stringFieldAnalyze));
                         break;
 
                     case JTokenType.TimeSpan:
@@ -146,7 +165,7 @@ namespace Lucene.Net.Mapping
                         break;
 
                     case JTokenType.Uri:
-                        doc.Add(new Field(prefix, value.Value.ToString(), Field.Store.NO, Field.Index.ANALYZED));
+						doc.Add(new Field(prefix, value.Value.ToString(), stringFieldStore, stringFieldAnalyze));
                         break;
 
                     default:
@@ -172,7 +191,7 @@ namespace Lucene.Net.Mapping
         /// <param name="obj">
         /// The JObject to add.
         /// </param>
-        private static void AddProperties(Document doc, string prefix, JObject obj)
+        private void AddProperties(Document doc, string prefix, JObject obj)
         {
             foreach (JProperty property in obj.Properties())
             {
@@ -192,7 +211,7 @@ namespace Lucene.Net.Mapping
         /// <param name="array">
         /// The JArray to add.
         /// </param>
-        private static void AddArray(Document doc, string prefix, JArray array)
+        private void AddArray(Document doc, string prefix, JArray array)
         {
             for (int i = 0; i < array.Count; i++)
             {
@@ -222,7 +241,8 @@ namespace Lucene.Net.Mapping
                 return String.Format("{0}.{1}", prefix, add);
             }
             else
-            {
+            
+			{
                 return add.ToString();
             }
         }

--- a/src/Lucene.Net.ObjectMapping/Mapping/MappingSettings.cs
+++ b/src/Lucene.Net.ObjectMapping/Mapping/MappingSettings.cs
@@ -12,7 +12,7 @@ namespace Lucene.Net.Mapping
         /// </summary>
         public static readonly MappingSettings Default = new MappingSettings()
         {
-            ObjectMapper = new JsonObjectMapper(),
+            ObjectMapper = new JsonObjectMapper(Conventions.Default),
         };
 
         /// <summary>


### PR DESCRIPTION
Added object mapping conventions & relevant unit test.
The aim is to provide a way to make certain string fields stored/not stored and analyzed/not analyzed based on convention.
